### PR TITLE
docs: fix casing for OpenFeature reference in code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ const OpenFeatureSplitProvider = require('@splitsoftware/openfeature-js-split-pr
 const authorizationKey = 'your auth key'
 const splitClient = SplitFactory({core: {authorizationKey}}).client();
 const provider = new OpenFeatureSplitProvider({splitClient});
-openFeature.setProvider(provider);
+OpenFeature.setProvider(provider);
 ```
 
 ## Use of OpenFeature with Split


### PR DESCRIPTION
Was going through the example for the JS SDK and found this issue.

Imported as `OpenFeature` but referenced by `openFeature`, so therefore `undefined` reference.